### PR TITLE
Enables bash "strict mode"

### DIFF
--- a/cli.sh
+++ b/cli.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
 
+# Enable 'strict mode'
+set -euo pipefail
+IFS=$'\n\t'
+
 # Configurable variables
 SALUTATION="Top o' the morning to ye"
 VALEDICTION="Fare thee well"

--- a/cron.sh
+++ b/cron.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 
-set -e
+# Enable 'strict mode'
+set -euo pipefail
+IFS=$'\n\t'
 
 BASENAME=$(basename $0)
 


### PR DESCRIPTION
Sensible defaults to preempt certain formatting-related bugs.

See: http://redsymbol.net/articles/unofficial-bash-strict-mode/
